### PR TITLE
add go vet with directory level go list

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,3 +14,8 @@
     description: Lint Cloudformation templates.
     entry: lint-cf.sh
     language: script
+-   id: go-vet
+    name: go-vet
+    description: Run go vet across all directories
+    entry: go-vet.sh
+    language: script

--- a/go-vet.sh
+++ b/go-vet.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+pkg=$(go list ./...)
+for dir in $(echo $@|xargs -n1 dirname|sort -u); do
+  go vet $pkg/$dir
+done

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -13,4 +13,8 @@
     name: lint-cf
     description: Lint Cloudformation templates.
     entry: lint-cf.sh
-
+-   id: go-vet
+    name: go-vet
+    description: Run go vet across all directories
+    entry: go-vet.sh
+    language: script


### PR DESCRIPTION
The current repo we use for the go vet hook does a flat ```go list``` operation so does not play well with repos with nested packages (i.e. the multi-binary worker being worked on). Added our own version here, which does a ```go list ./...```. May be preferable to maintain this ourselves anyway as it's simple and we can adapt it as necessary.