### PR TITLE
do not error on cfn-lint warnings

### DIFF
--- a/lint-cf.sh
+++ b/lint-cf.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-set -e
+cfn-lint template.yml
+EXIT_CODE=$?
 
-cfn-lint template.yml && echo $?
+# Exit code 4 is warnings, which we don't want to error. See https://github.com/aws-cloudformation/cfn-python-lint/issues/235#issuecomment-406951041
+if [ $EXIT_CODE == 4 ]; then
+  EXIT_CODE=0
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
cfn-lint warnings should not fail the pre commit hooks, so this change inspects the error code and only returns a failure when there is an error. See https://github.com/aws-cloudformation/cfn-python-lint/issues/235#issuecomment-406951041 for reference of error codes